### PR TITLE
Embed reviews in spots, fixed spot PUT, added spot PATCH, updated tests

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -33,9 +33,23 @@ def spots():
         return jsonify(spots), 200
 
 
-@route_blueprint.route("/api/spots/<id>", methods=["GET", "PUT", "DELETE"])
+@route_blueprint.route("/api/spots/<id>", methods=["GET", "PUT", "PATCH", "DELETE"])
 def spot_by_id(id):
     if request.method == "PUT":
+        body = request.json
+        spot = Spot(_id=id)
+        if "name" in body:
+            spot.name = body["name"]
+        if "description" in body:
+            spot.description = body["description"]
+        if "reviews" in body:
+            for review in body["reviews"]:
+                reviewModel = Review(author=review["author"], rating=review["rating"])
+                spot.reviews.append(reviewModel)
+        spot.save()
+        return jsonify(spot.to_son().to_dict()), 200
+
+    elif request.method == "PATCH":
         body = request.json
         try:
             spot = Spot.objects.get({"_id": ObjectId(id)})
@@ -45,6 +59,11 @@ def spot_by_id(id):
             spot.name = body["name"]
         if "description" in body:
             spot.description = body["description"]
+        if "reviews" in body:
+            spot.reviews = []
+            for review in body["reviews"]:
+                reviewModel = Review(author=review["author"], rating=review["rating"])
+                spot.reviews.append(reviewModel)
         spot.save()
         return jsonify(spot.to_son().to_dict()), 200
 

--- a/src/utils/models.py
+++ b/src/utils/models.py
@@ -3,7 +3,20 @@ Database Models
 
 Schema: MongoDB
 """
-from pymodm import MongoModel, fields
+from bson import SON
+from pymodm import EmbeddedMongoModel, MongoModel, fields
+
+
+class Review(EmbeddedMongoModel):
+    """
+    Review Model -- Represents a Review of a Study Spot
+    """
+
+    author = fields.CharField()
+    rating = fields.FloatField()
+
+    def __str__(self):
+        return f"Review of {self.spot_id}: {self.rating} ({self.author})"
 
 
 class Spot(MongoModel):
@@ -13,19 +26,7 @@ class Spot(MongoModel):
 
     name = fields.CharField()
     description = fields.CharField()
+    reviews = fields.EmbeddedDocumentListField(Review, default=[])
 
     def __str__(self):
         return f"Spot {self.name}: {self.description}"
-
-
-class Review(MongoModel):
-    """
-    Review Model -- Represents a Review of a Study Spot
-    """
-
-    spot_id = fields.ReferenceField(Spot)
-    author = fields.CharField()
-    rating = fields.FloatField()
-
-    def __str__(self):
-        return f"Review of {self.spot_id}: {self.rating} ({self.author})"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2,7 +2,7 @@ import config
 import pytest
 from bson import ObjectId
 from src.app_factory import create_app
-from src.utils.models import Spot
+from src.utils.models import Review, Spot
 
 
 @pytest.fixture()
@@ -40,6 +40,20 @@ def test_get_one(client):
     spot.save()
     response = client.get(f"/api/spots/{spot._id}")
     assert response.status_code == 200 and response.json["name"] == "Test Spot Get One"
+
+
+def test_get_one_with_reviews(client):
+    spot = Spot(
+        name="Test Spot Get One With Reviews",
+        description="Test Description",
+        reviews=[Review(author="Test Author", rating=5.0)],
+    )
+    spot.save()
+    response = client.get(f"/api/spots/{spot._id}")
+    assert (
+        response.status_code == 200
+        and response.json["reviews"][0]["author"] == "Test Author"
+    )
 
 
 def test_get_nonexistent(client):
@@ -87,7 +101,11 @@ def test_delete_nonexistent(client):
 
 
 def test_put(client):
-    spot = Spot(name="Test Spot Put Unchanged", description="Test Description")
+    spot = Spot(
+        name="Test Spot Put Unchanged",
+        description="Test Description",
+        reviews=[Review()],
+    )
     spot.save()
     response = client.put(
         f"/api/spots/{spot._id}",
@@ -98,6 +116,28 @@ def test_put(client):
     assert (
         changed.name == "Test Spot Put Changed"
         and changed.description == "Test Description"
+        and not changed.reviews
+    )
+
+
+def test_put_reviews(client):
+    spot = Spot(name="Test Spot Put Unchanged", description="Test Description")
+    spot.save()
+    response = client.put(
+        f"/api/spots/{spot._id}",
+        json={
+            "name": "Test Spot Put Changed",
+            "description": "Test Description",
+            "reviews": [{"author": "Test Author", "rating": 5.0}],
+        },
+    )
+    assert response.status_code == 200
+    changed = Spot.objects.get({"_id": spot._id})
+    assert (
+        changed.name == "Test Spot Put Changed"
+        and changed.description == "Test Description"
+        and len(changed.reviews) == 1
+        and changed.reviews[0].author == "Test Author"
     )
 
 
@@ -105,5 +145,47 @@ def test_put_nonexistent(client):
     response = client.put(
         f"/api/spots/{ObjectId()}",
         json={"name": "Test Spot Put Changed", "description": "Test Description"},
+    )
+    assert response.status_code == 200
+    spot = Spot.objects.get({"_id": ObjectId(response.json["_id"])})
+    assert spot.name == response.json["name"]
+
+
+def test_patch(client):
+    spot = Spot(name="Test Spot Patch", description="Test Description")
+    spot.save()
+    response = client.patch(
+        f"/api/spots/{spot._id}",
+        json={"description": "Changed Description"},
+    )
+    assert response.status_code == 200
+    changed = Spot.objects.get({"_id": spot._id})
+    assert (
+        changed.name == "Test Spot Patch"
+        and changed.description == "Changed Description"
+    )
+
+
+def test_patch_reviews(client):
+    spot = Spot(name="Test Spot Patch", description="Test Description")
+    spot.save()
+    response = client.patch(
+        f"/api/spots/{spot._id}",
+        json={"reviews": [{"author": "Test Author", "rating": 5.0}]},
+    )
+    assert response.status_code == 200
+    changed = Spot.objects.get({"_id": spot._id})
+    assert (
+        changed.name == "Test Spot Patch"
+        and changed.description == "Test Description"
+        and len(changed.reviews) == 1
+        and changed.reviews[0].author == "Test Author"
+    )
+
+
+def test_patch_nonexistent(client):
+    response = client.patch(
+        f"/api/spots/{ObjectId()}",
+        json={"description": "Test Description"},
     )
     assert response.status_code == 404


### PR DESCRIPTION
Reviews are now embedded in a `reviews` attribute on Spots. I updated `PUT` to work as it should and fully replace the object, and added `PATCH` for partial updates. While this implementation is RESTful (I believe), do we want to add a separate endpoint for adding reviews? As is adding a new review requires a Spot `PATCH` request with the current reviews list plus the new review.